### PR TITLE
Added fields 'Business Development' ,'Regional Sales Executive’ and ‘…

### DIFF
--- a/PageExtensions/Pag-Ext52607.CustomerCard.al
+++ b/PageExtensions/Pag-Ext52607.CustomerCard.al
@@ -15,8 +15,14 @@ pageextension 52607 "ORB Customer Card" extends "Customer Card"
             field("ORB Customer Support"; Rec."ORB Customer Support")
             {
                 ApplicationArea = all;
-                ToolTip = 'Specifies Orbus ustomer Support';
+                ToolTip = 'Specifies Orbus Customer Support';
             }
+            field("ORB Business Development"; Rec."ORB Business Development")
+            {
+                ApplicationArea = all;
+                ToolTip = 'Specifies Orbus Business Development';
+            }
+
         }
         addlast(General)
         {
@@ -26,6 +32,7 @@ pageextension 52607 "ORB Customer Card" extends "Customer Card"
                 ToolTip = 'Specifies Auto Send Email from JQ for the customer';
             }
         }
+
         modify("Salesperson Code")
         {
             Caption = 'Key/National Account Manager';

--- a/PageExtensions/Pag-Ext52627.CustomerList.al
+++ b/PageExtensions/Pag-Ext52627.CustomerList.al
@@ -43,6 +43,13 @@ pageextension 52627 "ORB Customer List" extends "Customer List"
                 ToolTip = 'Regional Sales Executive';
                 Caption = 'Regional Sales Executive';
             }
+            field("ORB Business Development"; Rec."ORB Business Development")
+            {
+                ApplicationArea = All;
+                Editable = false;
+                ToolTip = 'Business Development';
+                Caption = 'Business Development';
+            }
 
         }
         modify("Salesperson Code")

--- a/TableExtensions/Tab-Ext52603.Customer.al
+++ b/TableExtensions/Tab-Ext52603.Customer.al
@@ -68,6 +68,12 @@ tableextension 52603 "ORB Customer" extends Customer
             TableRelation = "Salesperson/Purchaser" where(Blocked = const(false));
             DataClassification = CustomerContent;
         }
+        field(52604; "ORB Business Development"; Code[20])
+        {
+            Caption = 'Business Development';
+            TableRelation = "Salesperson/Purchaser" where(Blocked = const(false));
+            DataClassification = CustomerContent;
+        }
         modify("Salesperson Code")
         {
             Caption = 'Key/National Account Manager';


### PR DESCRIPTION
…Customer Support’ to Customer table, Customer card, Customer List

changed the caption for 'Salesperson Code' on the Customer card and the Customer list. Changed to '’Key/National Account Manager’